### PR TITLE
Docs: Fix Quickstart Link

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-[Quickstart](./quickstart) | Configuration | [Permalinks](./permalinks.md) | [Pagination](./pagination.md) | [Layouts](./layouts.md)
+[Quickstart](./quickstart.md) | Configuration | [Permalinks](./permalinks.md) | [Pagination](./pagination.md) | [Layouts](./layouts.md)
 
 The following plugin options are available:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Documentation
 
-[Quickstart](./quickstart) | [Configuration](./configuration.md) | [Permalinks](./permalinks.md) | [Pagination](./pagination.md) | [Layouts](./layouts.md)
+[Quickstart](./quickstart.md) | [Configuration](./configuration.md) | [Permalinks](./permalinks.md) | [Pagination](./pagination.md) | [Layouts](./layouts.md)
 
 Gatsby Collections creates pages for collections of Markdown files, with support for pagination, customizable permalinks, and configurable layouts.
 

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -1,6 +1,6 @@
 # Layouts
 
-[Quickstart](./quickstart) | [Configuration](./configuration.md) | [Permalinks](./permalinks.md) | [Pagination](./pagination.md) | Layouts
+[Quickstart](./quickstart.md) | [Configuration](./configuration.md) | [Permalinks](./permalinks.md) | [Pagination](./pagination.md) | Layouts
 
 Layouts are React components used to render an item in your collection (or a page of items, in the case of pagination).
 

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -1,6 +1,6 @@
 # Pagination
 
-[Quickstart](./quickstart) | [Configuration](./configuration.md) | [Permalinks](./permalinks.md) | Pagination | [Layouts](./layouts.md)
+[Quickstart](./quickstart.md) | [Configuration](./configuration.md) | [Permalinks](./permalinks.md) | Pagination | [Layouts](./layouts.md)
 
 Support for paginated collections is built in, and easy to configure. Update your collection object with a `paginate` key, specifying [the layout to use for pagination](./layouts.md#pagination-layouts) and, optionally, the number of items to display per page:
 

--- a/docs/permalinks.md
+++ b/docs/permalinks.md
@@ -1,6 +1,6 @@
 # Permalinks
 
-[Quickstart](./quickstart) | [Configuration](./configuration.md) | Permalinks | [Pagination](./pagination.md) | [Layouts](./layouts.md)
+[Quickstart](./quickstart.md) | [Configuration](./configuration.md) | Permalinks | [Pagination](./pagination.md) | [Layouts](./layouts.md)
 
 Permalinks are template strings that define how an item's URL is constructed. They contain [placeholder values](#permalink-template-variables) (i.e. `:collection`) that are replaced by actual values during the Gatsby build process. The default permalink template is the [`pretty` preset](#presets).
 


### PR DESCRIPTION
## Docs: Fix Quickstart Link

This update fixes the link to "Quickstart" (`quickstart.md`). Previously,
the markdown link was missing the `.md` extension, resulting in a broken
link.

This update was made to all the pages under `docs/`.

Before:
```
[Quickstart](./quickstart)
```

After:
```
[Quickstart](./quickstart.md)
```